### PR TITLE
[BUGFIX] - Issue with http headers that aren't lowercase, setting all of them as lowercase

### DIFF
--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -86,14 +86,8 @@ pub fn merge_extensions(
     server_extensions: Option<Extensions>,
     client_extensions: Option<Extensions>,
 ) -> Option<Extensions> {
-    let server_ext = match server_extensions {
-        Some(ext) => ext,
-        None => return None,
-    };
-    let client_ext = match client_extensions {
-        Some(ext) => ext,
-        None => return None,
-    };
+    let server_ext = server_extensions?;
+    let client_ext = client_extensions?;
     let merged_extensions = Extensions {
         permessage_deflate: client_ext.permessage_deflate && server_ext.permessage_deflate,
         client_no_context_takeover: server_ext

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -29,10 +29,10 @@ pub(crate) const HTTP_ACCEPT_RESPONSE: &str = "HTTP/1.1 101 Switching Protocols\
         ";
 
 const HTTP_METHOD: &str = "GET";
-pub(crate) const SEC_WEBSOCKET_KEY: &str = "Sec-WebSocket-Key";
-pub(crate) const SEC_WEBSOCKET_EXTENSIONS: &str = "Sec-WebSocket-Extensions";
-pub(crate) const SEC_WEBSOCKET_ACCEPT: &str = "Sec-WebSocket-Accept";
-const HOST: &str = "Host";
+pub(crate) const SEC_WEBSOCKET_KEY: &str = "sec-websocket-key";
+pub(crate) const SEC_WEBSOCKET_EXTENSIONS: &str = "sec-websocket-extensions";
+pub(crate) const SEC_WEBSOCKET_ACCEPT: &str = "sec-websocket-accept";
+const HOST: &str = "host";
 
 pub type Result = std::result::Result<WSConnection, Error>;
 
@@ -282,13 +282,7 @@ async fn parse_handshake_client(
     // Some websockets server returns the SEC_WEBSOCKET_ACCEPT header, as lowercase.
     // Therefore, we need to cover both cases, for the sake of having support, even though it's
     // out of RFC standards
-    let sec_websocket_accept = if let Some(value) = req.get_header_value(SEC_WEBSOCKET_ACCEPT) {
-        value
-    } else {
-        req.get_header_value(SEC_WEBSOCKET_ACCEPT.to_lowercase().as_str())
-            .unwrap_or_default()
-    };
-
+    let sec_websocket_accept =  req.get_header_value(SEC_WEBSOCKET_ACCEPT).unwrap_or_default();
     if !sec_websocket_accept.contains(&expected_accept_value) {
         return Err(Error::InvalidAcceptKey);
     }

--- a/src/request.rs
+++ b/src/request.rs
@@ -114,7 +114,7 @@ impl HttpRequest {
         let mut headers = HashMap::new();
         for line in lines {
             if let Some((key, value)) = line.split_once(": ") {
-                headers.insert(key.to_string(), value.trim().to_string());
+                headers.insert(key.to_string().to_lowercase(), value.trim().to_string());
             }
         }
 


### PR DESCRIPTION
## [BUGFIX] - Issue with http headers that aren't lowercase, setting all of them as lowercase

## Description

This PR is related to the [issue](https://github.com/felipemeriga/socket-flow/issues/20)

## About the Issue

The issue was that the internal HTTP parser was keeping the headers names as they come from, and by the standards the HTTP headers need to be lowercase after passing through the library.

As we weren't forcing the name of each header as lowercase. Some websockets servers sends the `SEC_WEBSOCKET_ACCEPT` header as `sec-websocket-accept`, while another ones send as `Sec-WebSocket-Accept`, this was making `socket-flow` compatible with some libraries, and not working with another ones.

This PR is parsing the HTTP request from the TCP connection, and setting all the headers as lowercase.

